### PR TITLE
JBTIS-64 update savara version to 2.1.2.Final

### DIFF
--- a/devstudio/site/compositeArtifacts.xml
+++ b/devstudio/site/compositeArtifacts.xml
@@ -31,7 +31,7 @@
     <child location="http://download.jboss.org/jbosstools/updates/development/juno/soa-tooling/modeshape/3.2.0.Alpha1/"/>
 
     <!-- SAVARA -->
-    <child location="http://download.jboss.org/savara/releases/updates/2.1.1.Final/"/>
+    <child location="http://download.jboss.org/savara/releases/updates/2.1.2.Final/"/>
 
     <!-- SWITCHYARD -->
     <child location="http://download.jboss.org/jbosstools/updates/stable/juno/soa-tooling/switchyard/0.8.0.Final/"/>

--- a/devstudio/site/compositeContent.xml
+++ b/devstudio/site/compositeContent.xml
@@ -31,7 +31,7 @@
     <child location="http://download.jboss.org/jbosstools/updates/development/juno/soa-tooling/modeshape/3.2.0.Alpha1/"/>
 
     <!-- SAVARA -->
-    <child location="http://download.jboss.org/savara/releases/updates/2.1.1.Final/"/>
+    <child location="http://download.jboss.org/savara/releases/updates/2.1.2.Final/"/>
 
     <!-- SWITCHYARD -->
     <child location="http://download.jboss.org/jbosstools/updates/stable/juno/soa-tooling/switchyard/0.8.0.Final/"/>

--- a/jbosstools/site/compositeArtifacts.xml
+++ b/jbosstools/site/compositeArtifacts.xml
@@ -31,7 +31,7 @@
     <child location="http://download.jboss.org/jbosstools/updates/development/juno/soa-tooling/modeshape/3.2.0.Alpha1/"/>
 
     <!-- SAVARA -->
-    <child location="http://download.jboss.org/savara/releases/updates/2.1.1.Final/"/>
+    <child location="http://download.jboss.org/savara/releases/updates/2.1.2.Final/"/>
 
     <!-- SWITCHYARD -->
     <child location="http://download.jboss.org/jbosstools/updates/stable/juno/soa-tooling/switchyard/0.8.0.Final/"/>

--- a/jbosstools/site/compositeContent.xml
+++ b/jbosstools/site/compositeContent.xml
@@ -31,7 +31,7 @@
     <child location="http://download.jboss.org/jbosstools/updates/development/juno/soa-tooling/modeshape/3.2.0.Alpha1/"/>
 
     <!-- SAVARA -->
-    <child location="http://download.jboss.org/savara/releases/updates/2.1.1.Final/"/>
+    <child location="http://download.jboss.org/savara/releases/updates/2.1.2.Final/"/>
 
     <!-- SWITCHYARD -->
     <child location="http://download.jboss.org/jbosstools/updates/stable/juno/soa-tooling/switchyard/0.8.0.Final/"/>


### PR DESCRIPTION
Update version of savara to 2.1.2.Final, but this is dependent upon the BPMN2 modeller version being updated to 0.2.5.
