### PR TITLE
JBTIS-134 update Locus repository URL

### DIFF
--- a/jbosstools/discovery/pom.xml
+++ b/jbosstools/discovery/pom.xml
@@ -105,7 +105,7 @@
             <artifact>
               <groupId>org.jboss.tools.integration-stack</groupId>
               <artifactId>target-platform</artifactId>
-              <version>4.1.0-SNAPSHOT</version>
+              <version>4.1.1-SNAPSHOT</version>
               <type>target</type>
               <classifier>base</classifier>
             </artifact>

--- a/jbosstools/site/pom.xml
+++ b/jbosstools/site/pom.xml
@@ -199,7 +199,7 @@
             <artifact>
               <groupId>org.jboss.tools.integration-stack</groupId>
               <artifactId>target-platform</artifactId>
-              <version>4.1.0-SNAPSHOT</version>
+              <version>4.1.1-SNAPSHOT</version>
               <type>target</type>
               <classifier>base</classifier>
             </artifact>
@@ -236,7 +236,7 @@
 		<!-- The repositories listed here match those in the target platform file. -->
 		<associateSite>http://download.jboss.org/jbosstools/updates/development/kepler/</associateSite>
 		<associateSite>http://download.jboss.org/jbosstools/updates/requirements/kepler/201306260900-R/</associateSite>
-		<associateSite>http://download.jboss.org/jbosstools/updates/integration/locus/1.0.0.x/</associateSite>
+		<associateSite>http://download.jboss.org/jbosstools/updates/integration/locus/1.1.0.CI/</associateSite>
 		<associateSite>http://download.jboss.org/jbosstools/updates/requirements/bpmn2-modeler/0.2.6.201306192132_S20130619_kepler/</associateSite>
 		<associateSite>http://download.jboss.org/jbosstools/updates/requirements/bpel/1.0.3.v20130509-1351-CI/</associateSite>
 		<associateSite>http://download.jboss.org/jbosstools/updates/integration/kepler/soa-tooling/fuse-tooling/7.2.0/all/repo/</associateSite>

--- a/target-platform/integration-stack-base.target
+++ b/target-platform/integration-stack-base.target
@@ -20,7 +20,7 @@
       <unit id="org.springframework.osgi.extender" version="1.2.1"/>
       <unit id="org.springframework.osgi.extensions.annotations" version="1.2.1"/>
       <unit id="org.springframework.osgi.io" version="1.2.1"/>
-      <repository location="http://download.jboss.org/jbosstools/updates/integration/locus/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/integration/locus/1.1.0.CI"/>
     </location>
 
     <!-- Eclipse Graphiti -->

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.jboss.tools.integration-stack</groupId>
   <artifactId>target-platform</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>4.1.1-SNAPSHOT</version>
 
   <name>JBoss Tools Integration Stack Target Platform</name>
   <description>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBTIS-134

This also includes an update to the target platform which was referencing the root locus folder (as opposed to a specific release).
