### PR TITLE
Add jbt-eclipse orbit to list of associated update sites

### DIFF
--- a/jbosstools/site/pom.xml
+++ b/jbosstools/site/pom.xml
@@ -236,6 +236,7 @@
 		<associateSite>http://download.jboss.org/jbosstools/updates/requirements/kepler/201306260900-R/</associateSite>
 		<associateSite>http://download.jboss.org/jbosstools/updates/stable/kepler/</associateSite>
 		<associateSite>http://download.jboss.org/jbosstools/targetplatforms/jbtistarget/4.1.1.Final/REPO/</associateSite>
+		<associateSite>http://download.jboss.org/jbosstools/updates/requirements/orbit/R20130517111416/</associateSite>
 	      </associateSites>
 
 	      <siteTemplateFolder>${siteTemplateFolder}</siteTemplateFolder>


### PR DESCRIPTION
- Adds reference to jbt's eclipse orbit to associate sites so that JBTIS
  plugins can find orbit plugins without having to query the repository
  separately.
- Example: Teiid Designer plugins require org.codehaus.jackson.core which
  is located in the orbit repository.
