### PR TITLE
Updating update-site URL for ModeShape Tools to the 3.4.0.Final version.

### DIFF
--- a/jbosstools/site/compositeArtifacts.xml
+++ b/jbosstools/site/compositeArtifacts.xml
@@ -32,7 +32,7 @@
     <!-- <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/jbpm/4.5.200.Final/"/> -->
 
     <!-- MODESHAPE -->
-    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/modeshape/3.3.0.Final/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/soa-tooling/modeshape/3.4.0.Final/"/>
 
     <!-- SAVARA -->
     <child location="http://download.jboss.org/savara/releases/updates/2.2.1.Final/"/>

--- a/jbosstools/site/compositeContent.xml
+++ b/jbosstools/site/compositeContent.xml
@@ -32,7 +32,7 @@
     <!-- <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/jbpm/4.5.200.Final/"/> -->
 
     <!-- MODESHAPE -->
-    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/modeshape/3.3.0.Final/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/soa-tooling/modeshape/3.4.0.Final/"/>
 
     <!-- SAVARA -->
     <child location="http://download.jboss.org/savara/releases/updates/2.2.1.Final/"/>


### PR DESCRIPTION
This version has some minor changes and uses the ModeShape 3.4 client jar.
