### PR TITLE
JBTIS-182 Publish to ModeShape: Finish Button Disabled

### DIFF
--- a/jbosstools/site/compositeArtifacts.xml
+++ b/jbosstools/site/compositeArtifacts.xml
@@ -35,7 +35,7 @@
     <!-- <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/jbpm/4.5.200.Final/"/> -->
 
     <!-- MODESHAPE -->
-    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/modeshape/3.4.0.Final/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/modeshape/3.5.0.Final/"/>
 
     <!-- SAVARA -->
     <child location="http://download.jboss.org/savara/releases/updates/2.2.2.Final/"/>

--- a/jbosstools/site/compositeContent.xml
+++ b/jbosstools/site/compositeContent.xml
@@ -35,7 +35,7 @@
     <!-- <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/jbpm/4.5.200.Final/"/> -->
 
     <!-- MODESHAPE -->
-    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/modeshape/3.4.0.Final/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/modeshape/3.5.0.Final/"/>
 
     <!-- SAVARA -->
     <child location="http://download.jboss.org/savara/releases/updates/2.2.2.Final/"/>


### PR DESCRIPTION
Updated to ModeShape Tools 3.5.0.Final. This release fixed an enablement issue on the publish dialog and upgraded to ModeShape client 3.5.0.Final. The IS site XML files have been changed to point to the new release. Tested with Kepler SR1 and ModeShape client 3.5.0.Final.
