### PR TITLE
Updates the teiid designer version to 8.3.Beta3

### DIFF
--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -31,8 +31,8 @@
     <BUILD_TYPE>integration</BUILD_TYPE>
     <PREFIX>jbosstools-integration-stack</PREFIX>
     <TARGET_PLATFORM>kepler</TARGET_PLATFORM>
-    <VERSION>4.1.3.Beta5</VERSION>
-    <IS_TP_VERSION>4.1.5.Beta2-SNAPSHOT</IS_TP_VERSION>
+    <VERSION>4.1.3.Beta6</VERSION>
+    <IS_TP_VERSION>4.1.5.Beta2</IS_TP_VERSION>
     <tycho-version>0.18.1</tycho-version>
     <jboss-tycho-version>0.16.0.CR2</jboss-tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jbosstools/site/compositeArtifacts.xml
+++ b/jbosstools/site/compositeArtifacts.xml
@@ -44,7 +44,7 @@
     <child location="http://download.jboss.org/jbosstools/updates/development/juno/integration-stack/switchyard/1.1.0.M3/"/>
 
     <!-- TEIID -->
-    <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/teiiddesigner/8.3.0.Beta2/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/teiiddesigner/8.3.0.Beta3/"/>
 
   </children>
 

--- a/jbosstools/site/compositeContent.xml
+++ b/jbosstools/site/compositeContent.xml
@@ -44,7 +44,7 @@
     <child location="http://download.jboss.org/jbosstools/updates/development/juno/integration-stack/switchyard/1.1.0.M3/"/>
 
     <!-- TEIID -->
-    <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/teiiddesigner/8.3.0.Beta2/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/teiiddesigner/8.3.0.Beta3/"/>
 
   </children>
 


### PR DESCRIPTION
- Also updates the IS version to 4.1.3.Beta6 in line with release procedures
- Removes the SNAPSHOT suffix from IS_TP_VERSION since 4.1.5.Beta2-SNAPSHOT cannot be found in nexus. DO NOT MERGE UNLESS THIS CHANGE IS CORRECT.
