### PR TITLE
JBTIS-231 bump SwitchYard to 1.1.2.Final

### DIFF
--- a/jbosstools/site/compositeArtifacts.xml
+++ b/jbosstools/site/compositeArtifacts.xml
@@ -36,7 +36,7 @@
     <child location="http://download.jboss.org/savara/releases/updates/2.2.2.Final/"/>
 
     <!-- SWITCHYARD -->
-    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/switchyard/1.1.1.Final/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/switchyard/1.1.2.Final/"/>
 
     <!-- TEIID -->
     <child location="http://download.jboss.org/jbosstools/updates/release/kepler/integration-stack/teiiddesigner/8.3.0.Final/"/>

--- a/jbosstools/site/compositeContent.xml
+++ b/jbosstools/site/compositeContent.xml
@@ -36,7 +36,7 @@
     <child location="http://download.jboss.org/savara/releases/updates/2.2.2.Final/"/>
 
     <!-- SWITCHYARD -->
-    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/switchyard/1.1.1.Final/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/stable/kepler/integration-stack/switchyard/1.1.2.Final/"/>
 
     <!-- TEIID -->
     <child location="http://download.jboss.org/jbosstools/updates/release/kepler/integration-stack/teiiddesigner/8.3.0.Final/"/>


### PR DESCRIPTION
I noticed ./jbosstools is still configured to use 4.1.5.Final-SNAPSHOT for the TP.
