### PR TITLE
JBTIS-297 - reinstate SwitchYard

### DIFF
--- a/jbosstools/site/category.xml
+++ b/jbosstools/site/category.xml
@@ -58,11 +58,11 @@ Tools related to the development of Integration and SOA applications - includes 
   <category name="SOADev" />
 </feature>
 
-<!-- fuse ide runtimes -->
+<!-- fuse ide runtimes 
 <feature id="org.fusesource.ide.runtimes.feature">
   <category name="SOADev" />
 </feature>
-
+-->
 <!-- fuse ide server extensions -->
 <feature id="org.fusesource.ide.server.extensions.feature">
   <category name="SOADev" />
@@ -121,17 +121,19 @@ Tools related to the development of Integration and SOA applications - includes 
   <category name="SOADev" />
 </feature>
 
-<!-- switchyard - temporary until rebuilt with new bpmn2 modeler
+<!-- switchyard -->
 <feature id="org.switchyard.tools.feature">
   <category name="SOADev" />
 </feature>
+
 <feature id="org.switchyard.tools.bpel.feature">
   <category name="SOADev" />
 </feature>
+
 <feature id="org.switchyard.tools.bpmn2.feature">
   <category name="SOADev" />
 </feature>
--->
+
 <!-- teiid 
 <feature id="org.teiid.datatools.connectivity.feature">
   <category name="DataVirtualization" />

--- a/jbosstools/site/compositeArtifacts.xml
+++ b/jbosstools/site/compositeArtifacts.xml
@@ -35,9 +35,9 @@
     <!-- SAVARA -->
     <child location="http://download.jboss.org/savara/releases/updates/2.2.2.Final/"/>
 
-    <!-- SWITCHYARD  - temporary until rebuilt with new bpmn2 modeler
-    <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/switchyard/2.0.0.Alpha2/"/>
-    -->
+    <!-- SWITCHYARD  -->
+    <child location="http://download.jboss.org/jbosstools/updates/integration/kepler/integration-stack/switchyard/2.0.0/"/>
+
     <!-- TEIID 
     <child location="http://download.jboss.org/jbosstools/updates/release/kepler/integration-stack/teiiddesigner/8.3.3.Final/"/>
     -->

--- a/jbosstools/site/compositeContent.xml
+++ b/jbosstools/site/compositeContent.xml
@@ -35,9 +35,9 @@
     <!-- SAVARA -->
     <child location="http://download.jboss.org/savara/releases/updates/2.2.2.Final/"/>
 
-    <!-- SWITCHYARD - temporary until rebuilt with new bpmn2 modeler
-    <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/switchyard/2.0.0.Alpha2/"/>
-    -->
+    <!-- SWITCHYARD -->
+    <child location="http://download.jboss.org/jbosstools/updates/integration/kepler/integration-stack/switchyard/2.0.0/"/>
+
     <!-- TEIID
     <child location="http://download.jboss.org/jbosstools/updates/release/kepler/integration-stack/teiiddesigner/8.3.3.Final/"/>
     -->


### PR DESCRIPTION
Also remove fuse org.fusesource.ide.runtimes.feature - it no longer exists.  A fuse-releated update will happen soon.
