### PR TITLE
Issue JBTIS-290 enable jboss tools usage tracking for plugins installed directly

### DIFF
--- a/jbosstools/site/compositeArtifacts.xml
+++ b/jbosstools/site/compositeArtifacts.xml
@@ -30,7 +30,7 @@
     <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/jbpm/4.5.200.Final/"/>
 
     <!-- MODESHAPE -->
-    <child location="http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/modeshape/3.7.0.Alpha1/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/modeshape/3.7.0.Beta1/"/>
 
     <!-- SWITCHYARD  -->
     <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/switchyard/2.0.0.Alpha3/"/>

--- a/jbosstools/site/compositeContent.xml
+++ b/jbosstools/site/compositeContent.xml
@@ -30,7 +30,7 @@
     <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/jbpm/4.5.200.Final/"/>
 
     <!-- MODESHAPE -->
-    <child location="http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/modeshape/3.7.0.Alpha1/"/>
+    <child location="http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/modeshape/3.7.0.Beta1/"/>
 
     <!-- SWITCHYARD -->
     <child location="http://download.jboss.org/jbosstools/updates/development/kepler/integration-stack/switchyard/2.0.0.Alpha3/"/>


### PR DESCRIPTION
Now both ModeShape Tools plugins can be tracked by the usage tracker.
