### PR TITLE
JBTIS-370 - updated bpel 1.0.4 for org.eclipse.bpel feature source bundl...

### DIFF
--- a/target-platform/integration-stack-base.target
+++ b/target-platform/integration-stack-base.target
@@ -111,10 +111,13 @@
 
     <!-- BPEL -->
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.bpel.common.feature.feature.group" version="1.0.4.v20140808-2040-CI"/>
-      <unit id="org.eclipse.bpel.feature.feature.group" version="1.0.4.v20140808-2040-CI"/>
-      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.feature.group" version="1.0.4.v20140808-2040-CI"/>
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/bpel/1.0.4.v20140808-2040-CI/"/>
+      <unit id="org.eclipse.bpel.common.feature.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.feature.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.common.feature.source.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.feature.source.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.source.feature.group" version="1.0.4.v201412041949"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/bpel/1.0.4.v201412041949/"/>
     </location>
 
     <!-- Fuse Tooling -->

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.jboss.tools.integration-stack</groupId>
   <artifactId>target-platform</artifactId>
-  <version>4.2.0.Beta2-SNAPSHOT</version>
+  <version>4.2.0.Beta2a-SNAPSHOT</version>
 
   <name>JBoss Tools Integration Stack Target Platform</name>
   <description>


### PR DESCRIPTION
...es

JBTIS TP 4.2.0.Beta2a - BPEL now includes org.eclipse.bpel source bundles for use in jbosstools-bpel and then in JBTIS/ JBDSIS.
