### PR TITLE
JBTIS-379 - add earlyaccess profile

### DIFF
--- a/devstudio/pom.xml
+++ b/devstudio/pom.xml
@@ -130,6 +130,24 @@ http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/re
 
       <modules>
 	<module>site-ga</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>earlyaccess</id>
+
+      <activation>
+        <property>
+          <name>BUILD_TYPE</name>
+          <value>stable</value>
+        </property>
+      </activation>
+
+      <properties>
+        <update.site.description>Early Access Release</update.site.description>
+      </properties>
+
+      <modules>
 	<module>site-ea</module>
       </modules>
     </profile>

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -120,6 +120,24 @@
 
       <modules>
 	<module>site-final</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>earlyaccess</id>
+
+      <activation>
+        <property>
+          <name>BUILD_TYPE</name>
+          <value>stable</value>
+        </property>
+      </activation>
+
+      <properties>
+        <update.site.description>Early Access Release</update.site.description>
+      </properties>
+
+      <modules>
 	<module>site-ea</module>
       </modules>
     </profile>


### PR DESCRIPTION
...on p2 update sites

Single build creates the site final/ga, site early access and site master.  Add 'stable' profile to enable new site builds.  Final and EA are now independent (no more superset).
