### PR TITLE
JBTIS-382 - create both EA and release TP artifacts under target-platfor...

### DIFF
--- a/devstudio/README.adoc
+++ b/devstudio/README.adoc
@@ -27,3 +27,6 @@
 
     mvn -DCOMPOSITE_SITE=file:///home/me/git-clone/jbosstools-integration-stack/jbosstools/site/target/repository/ clean install -Pstable
 
+# To build using local target platform and local jbosstools:
+
+    mvn -U -Dtycho.localArtifacts=ignore -DIS_TP_VERSION=4.2.1.CR1 -DCOMPOSITE_SITE=file:///home/me/jbosstools-integration-stack/jbosstools/site/target/repository/ -Dtargetplatform.url=file:///home/me/jbosstools-integration-stack/target-platform/target/target-platform-ea.target.repo clean install

--- a/devstudio/pom.xml
+++ b/devstudio/pom.xml
@@ -30,10 +30,11 @@ http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/re
       mvn clean install
 
       If have already generated a local JBTIS build, can use this instead of a published site for upstream JBTIS COMPOSITE_SITE:
-      -DCOMPOSITE_SITE=file://`pwd`/../jbosstools/site/target/repository/
+      -DCOMPOSITE_SITE=file://`pwd`/../jbosstools/site/target/repository/ 
+      -DCOMPOSITE_EA_SITE=file://`pwd`/../jbosstools/site-ea/target/repository/ 
 
       If have already generated a local JBTIS TP build, can use this instead of pulling down the TP from remote:
-      -Dtargetplatform.url=file:///....
+      -Dtargetplatform.url=file:///.... -DIS_TP_VERSION=4.2.1.Final
   -->
   <properties>
     <BUILD_ALIAS>LOCAL</BUILD_ALIAS>
@@ -43,7 +44,7 @@ http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/re
     <PREFIX>devstudio-integration-stack</PREFIX>
     <TARGET_PLATFORM>luna</TARGET_PLATFORM>
     <VERSION>8.0.0.CR2</VERSION>
-    <IS_TP_VERSION>4.2.1.Final</IS_TP_VERSION>
+    <IS_TP_VERSION>4.2.1.CR1</IS_TP_VERSION>
     <tycho-version>0.21.0</tycho-version>
     <jboss-tycho-version>0.21.1</jboss-tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -61,7 +62,7 @@ http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/re
     <target.eclipse.version>4.4 (Luna) or &lt;a href="https://www.jboss.org/products/devstudio/overview/"&gt;JBoss Developer Studio 8&lt;/a&gt;</target.eclipse.version>
 
     <!-- The URL for the JBTIS target platform that should be associated with this site. -->
-    <targetplatform.url>http://download.jboss.org/jbosstools/builds/staging/JBTIS-target-platform/4.2.1.Final/earlyaccess/REPO/</targetplatform.url>
+    <targetplatform.url>http://download.jboss.org/jbosstools/builds/staging/JBTIS-target-platform/${IS_TP_VERSION}/earlyaccess/REPO/</targetplatform.url>
 
     <!-- The version to use for the target platform, defaults to project version. -->
     <targetplatform.version>${project.version}</targetplatform.version>
@@ -122,7 +123,7 @@ http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/re
       <properties>
         <update.site.description>Stable Release</update.site.description>
 	<!-- The URL for the JBTIS target platform that should be associated with this site. -->
-	<targetplatform.url>http://download.jboss.org/jbosstools/builds/staging/JBTIS-target-platform/4.2.1.Final/REPO/</targetplatform.url>
+	<targetplatform.url>http://download.jboss.org/jbosstools/builds/staging/JBTIS-target-platform/4.2.1.CR1/REPO/</targetplatform.url>
       </properties>
 
       <modules>

--- a/devstudio/pom.xml
+++ b/devstudio/pom.xml
@@ -15,14 +15,14 @@
     JBDS Integration Stack Aggregate update site + Central Discovery plugin, directory, and composite site generation.
   </description>
 
-  <!-- Run a build like this:
-      mvn clean install -DTARGET_PLATFORM=luna -DBUILD_TYPE=integration -DIS_TP_VERSION=4.2.0.Alpha8 -DVERSION=8.0.0.Alpha2 \
+  <!-- Run a build like this to generate release and early access update sites:
+      mvn clean install -DTARGET_PLATFORM=luna -DBUILD_TYPE=integration -DIS_TP_VERSION=4.2.1.Final -DVERSION=8.0.0.GA \
       -DBUILD_NUMBER=111 -DBUILD_ALIAS=CI-2013-08-21_20-10-23-B111 \
-      -DCOMPOSITE_SITE=http://download.jboss.org/jbosstools/updates/integration/kepler/integration-stack/aggregate/4.2.0.Alpha8/ \
+      -DCOMPOSITE_SITE=http://download.jboss.org/jbosstools/updates/stable/luna/integration-stack/aggregate/4.2.0.Final/ \
       -DUPSTREAM_DIRECTORY_XML=https://devstudio.redhat.com/updates/8.0-development/devstudio-directory.xml \
       -DCOMPOSITE_URLS=https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.0.0.GA-updatesite-core/,\
 https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.0.0.GA-target-platform/,\
-https://devstudio.redhat.com/updates/8.0.0/8.0.0.Alpha2.jbds-is-target-platform/,\
+https://devstudio.redhat.com/updates/8.0.0/8.0.0.GA.jbds-is-target-platform/,\
 http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/repo/
 
       -or-
@@ -34,12 +34,6 @@ http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/re
 
       If have already generated a local JBTIS TP build, can use this instead of pulling down the TP from remote:
       -Dtargetplatform.url=file:///....
-
-      -or-
-
-      mvn clean install -Pstable
-
-      To generate .GA and early access update sites.
   -->
   <properties>
     <BUILD_ALIAS>LOCAL</BUILD_ALIAS>
@@ -49,7 +43,7 @@ http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/re
     <PREFIX>devstudio-integration-stack</PREFIX>
     <TARGET_PLATFORM>luna</TARGET_PLATFORM>
     <VERSION>8.0.0.CR2</VERSION>
-    <IS_TP_VERSION>4.2.0.Final</IS_TP_VERSION>
+    <IS_TP_VERSION>4.2.1.Final</IS_TP_VERSION>
     <tycho-version>0.21.0</tycho-version>
     <jboss-tycho-version>0.21.1</jboss-tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -67,7 +61,7 @@ http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/re
     <target.eclipse.version>4.4 (Luna) or &lt;a href="https://www.jboss.org/products/devstudio/overview/"&gt;JBoss Developer Studio 8&lt;/a&gt;</target.eclipse.version>
 
     <!-- The URL for the JBTIS target platform that should be associated with this site. -->
-    <targetplatform.url>http://download.jboss.org/jbosstools/builds/staging/JBTIS-target-platform/4.2.0.Final/REPO/</targetplatform.url>
+    <targetplatform.url>http://download.jboss.org/jbosstools/builds/staging/JBTIS-target-platform/4.2.1.Final/earlyaccess/REPO/</targetplatform.url>
 
     <!-- The version to use for the target platform, defaults to project version. -->
     <targetplatform.version>${project.version}</targetplatform.version>
@@ -127,6 +121,8 @@ http://download.jboss.org/jbosstools/builds/staging/JBDSIS-aggregate-disc/all/re
 
       <properties>
         <update.site.description>Stable Release</update.site.description>
+	<!-- The URL for the JBTIS target platform that should be associated with this site. -->
+	<targetplatform.url>http://download.jboss.org/jbosstools/builds/staging/JBTIS-target-platform/4.2.1.Final/REPO/</targetplatform.url>
       </properties>
 
       <modules>

--- a/devstudio/site-ea/pom.xml
+++ b/devstudio/site-ea/pom.xml
@@ -78,14 +78,14 @@
           </environments>
 
           <!-- Pick up the merged target dependencies of the JBoss Tools core unified target and the base
-	       JBoss Tools Integration Stack. -->
+	       JBoss Tools Integration Stack (early access). -->
           <target>
             <artifact>
               <groupId>org.jboss.tools.integration-stack</groupId>
               <artifactId>target-platform</artifactId>
               <version>${IS_TP_VERSION}</version>
               <type>target</type>
-              <classifier>base</classifier>
+              <classifier>base-ea</classifier>
             </artifact>
           </target>
         </configuration>

--- a/devstudio/site/pom.xml
+++ b/devstudio/site/pom.xml
@@ -133,14 +133,14 @@
           </environments>
 
           <!-- Pick up the merged target dependencies of the JBoss Tools core unified target and the base
-	       JBoss Tools Integration Stack. -->
+	       (early access) JBoss Tools Integration Stack. -->
           <target>
             <artifact>
               <groupId>org.jboss.tools.integration-stack</groupId>
               <artifactId>target-platform</artifactId>
               <version>${IS_TP_VERSION}</version>
               <type>target</type>
-              <classifier>base</classifier>
+              <classifier>base-ea</classifier>
             </artifact>
           </target>
         </configuration>

--- a/jbosstools/README.adoc
+++ b/jbosstools/README.adoc
@@ -19,6 +19,6 @@
 
 (Taken from console log of https://jenkins.mw.lab.eng.bos.redhat.com/hudson/view/DevStudio/view/JBTIS/job/JBTIS-aggregate-disc )
 
-# To build stable release update sites:
+# To build referencing your own JBTIS target platform, build ../target-platform first, then:
 
-    mvn clean install -Pstable
+    mvn -U -Dtycho.localArtifacts=ignore -DIS_TP_VERSION=4.2.1.CR1 -Dtargetplatform.url=file:///home/me/jbosstools-integration-stack/target-platform/target/target-platform-ea.target.repo clean install

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -28,7 +28,8 @@
 
       mvn clean install
 
-      To generate .Final and early access update sites.
+      If have already generated a local JBTIS TP build, can use this instead of pulling down the TP from remote:
+      -Dtargetplatform.url=file:///.... -DIS_TP_VERSION=4.2.1.Final
   -->
   <properties>
     <BUILD_ALIAS>LOCAL</BUILD_ALIAS>
@@ -38,7 +39,7 @@
     <PREFIX>jbosstools-integration-stack</PREFIX>
     <TARGET_PLATFORM>luna</TARGET_PLATFORM>
     <VERSION>4.2.0.CR2</VERSION>
-    <IS_TP_VERSION>4.2.1.Final</IS_TP_VERSION>
+    <IS_TP_VERSION>4.2.1.CR1</IS_TP_VERSION>
     <tycho-version>0.21.0</tycho-version>
     <jboss-tycho-version>0.21.1</jboss-tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -22,15 +22,11 @@
       -DUPSTREAM_DIRECTORY_XML=http://download.jboss.org/jbosstools/updates/development/luna/jbosstools-directory.xml \
       -DCOMPOSITE_URLS=http://download.jboss.org/jbosstools/updates/development/luna/,\
        http://download.jboss.org/jbosstools/updates/integration/luna/integration-stack/aggregate/4.2.0.Final/,\
-       http://download.jboss.org/jbosstools/targetplatforms/jbtistarget/4.2.0.Final/REPO/
+       http://download.jboss.org/jbosstools/targetplatforms/jbtistarget/4.2.1.Final/earlyaccess/REPO/
 
       -or-
 
       mvn clean install
-
-      -or-
-
-      mvn clean install -Pstable
 
       To generate .Final and early access update sites.
   -->
@@ -42,14 +38,14 @@
     <PREFIX>jbosstools-integration-stack</PREFIX>
     <TARGET_PLATFORM>luna</TARGET_PLATFORM>
     <VERSION>4.2.0.CR2</VERSION>
-    <IS_TP_VERSION>4.2.0.Final</IS_TP_VERSION>
+    <IS_TP_VERSION>4.2.1.Final</IS_TP_VERSION>
     <tycho-version>0.21.0</tycho-version>
     <jboss-tycho-version>0.21.1</jboss-tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <target.eclipse.version>4.4 (Luna) or &lt;a href="https://www.jboss.org/products/devstudio/overview/"&gt;JBoss Developer Studio 8&lt;/a&gt;</target.eclipse.version>
 
     <!-- The URL for the JBTIS target platform that should be associated with this site. -->
-    <targetplatform.url>http://download.jboss.org/jbosstools/builds/staging/JBTIS-target-platform/4.2.0.Final/REPO/</targetplatform.url>
+    <targetplatform.url>http://download.jboss.org/jbosstools/builds/staging/JBTIS-target-platform/${IS_TP_VERSION}/earlyaccess/REPO/</targetplatform.url>
 
     <!-- The version to use for the target platform, defaults to project version. -->
     <targetplatform.version>${project.version}</targetplatform.version>
@@ -67,6 +63,8 @@
   <modules>
     <module>site</module>
     <module>discovery</module>
+    <module>site-final</module>
+    <module>site-ea</module>
   </modules>
 
   <profiles>  
@@ -117,10 +115,6 @@
       <properties>
         <update.site.description>Stable Release</update.site.description>
       </properties>
-
-      <modules>
-	<module>site-final</module>
-      </modules>
     </profile>
 
     <profile>
@@ -136,10 +130,6 @@
       <properties>
         <update.site.description>Early Access Release</update.site.description>
       </properties>
-
-      <modules>
-	<module>site-ea</module>
-      </modules>
     </profile>
   </profiles>
 

--- a/jbosstools/site-ea/pom.xml
+++ b/jbosstools/site-ea/pom.xml
@@ -92,14 +92,14 @@
           </environments>
 
           <!-- Pick up the merged target dependencies of the JBoss Tools core unified target and the base
-	       JBoss Tools Integration Stack. -->
+	       (early access) JBoss Tools Integration Stack. -->
           <target>
             <artifact>
               <groupId>org.jboss.tools.integration-stack</groupId>
               <artifactId>target-platform</artifactId>
               <version>${IS_TP_VERSION}</version>
               <type>target</type>
-              <classifier>base</classifier>
+              <classifier>base-ea</classifier>
             </artifact>
           </target>
         </configuration>

--- a/jbosstools/site/pom.xml
+++ b/jbosstools/site/pom.xml
@@ -162,14 +162,14 @@
           </environments>
 
           <!-- Pick up the merged target dependencies of the JBoss Tools core unified target and the
-	       full JBoss Tools Integration Stack (with community). -->
+	       full JBoss Tools Integration Stack (with community, early access). -->
           <target>
             <artifact>
               <groupId>org.jboss.tools.integration-stack</groupId>
               <artifactId>target-platform</artifactId>
               <version>${IS_TP_VERSION}</version>
               <type>target</type>
-              <classifier>full</classifier>
+              <classifier>full-ea</classifier>
             </artifact>
           </target>
         </configuration>

--- a/target-platform/integration-stack-base-ea.target
+++ b/target-platform/integration-stack-base-ea.target
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+
+<!-- 
+   Mirrored third-party and Eclipse dependencies for the JBoss Tools Integration Stack.
+
+   This target file contains all dependent features/ plugins (released or not) to form
+   the early access target platform.
+-->
+<target name="integration-stack-base-target" sequenceNumber="7">
+  <locations>
+
+    <!-- JBoss Tools Locus - objects either not in Eclipse Orbit or needed sooner than scheduled. -->
+    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <unit id="org.apache.servicemix.bundles.aopalliance" version="1.0.0.3"/>
+
+      <unit id="org.jboss.tools.locus.jcip.annotations" version="1.0.0.Final-v20131024-0922-B58"/>
+      <unit id="org.jboss.tools.locus.mockito" version="1.9.5.Final_patched_TEIIDDES-1681-v20131024-0922-B58"/>
+      <unit id="org.jboss.tools.locus.sf.saxon" version="9.2.1.5j-Final-v20131024-0922-B58"/>
+
+      <unit id="org.springframework.aspects" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.osgi.core" version="1.2.1"/>
+      <unit id="org.springframework.osgi.extender" version="1.2.1"/>
+      <unit id="org.springframework.osgi.extensions.annotations" version="1.2.1"/>
+      <unit id="org.springframework.osgi.io" version="1.2.1"/>
+      <repository location="https://repository.jboss.org/nexus/content/unzip/unzip/org/jboss/tools/locus/update.site/1.1.1.Final/update.site-1.1.1.Final.zip-unzip/"/>
+    </location>
+
+    <!-- transitive dependencies for org.springframework.* -->
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <unit id="org.springframework.aop" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.beans" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.context" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.core" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.expression" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.transaction" version="3.1.4.RELEASE"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.2.0.201303060654-RELEASE-e4.3/"/>
+    </location>
+
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
+
+      <!-- transitive dependencies -->
+      <unit id="com.ibm.icu" version="52.1.0.v201404241930"/>
+      <unit id="javax.xml" version="1.3.4.v201005080400"/>
+      <unit id="org.apache.ant" version="1.9.2.v201404171502"/>
+      <unit id="org.apache.commons.codec" version="1.6.0.v201305230611"/>
+      <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
+      <unit id="org.apache.commons.logging" version="1.0.4.v201101211617"/>
+      <unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
+
+      <unit id="org.eclipse.draw2d" version="3.9.100.201405261516"/>
+      <unit id="org.eclipse.equinox.simpleconfigurator.manipulator" version="2.0.0.v20131217-1203"/>
+      <unit id="org.eclipse.jdt.junit.core" version="3.7.300.v20140409-1618"/>
+      <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
+      <unit id="org.jsoup" version="1.7.2.v201304221138"/>
+      <unit id="org.junit" version="4.11.0.v201303080030"/>
+
+      <!-- Eclipse EMF -->
+      <unit id="org.eclipse.emf.compare.feature.group" version="3.0.0.201406111328"/>
+      <unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.0.0.201406111328"/>
+      <unit  id="org.eclipse.emf.compare.rcp" version="2.2.0.201406111328"/>
+      <unit  id="org.eclipse.emf.compare.rcp.ui" version="4.0.0.201406111328"/>
+
+      <!-- Eclipse EMF/OCL + deps like EMF Query and UML2 -->
+      <unit id="org.eclipse.emf.validation.ocl.feature.group" version="1.8.0.201405281429"/>
+      <unit id="org.eclipse.emf.query.ocl.feature.group" version="1.8.0.201405281426"/>
+      <unit id="org.eclipse.emf.query.feature.group" version="1.8.0.201405281426"/>
+      <unit id="org.eclipse.emf.transaction.feature.group" version="1.8.0.201405281451"/>
+      <unit id="org.eclipse.emf.validation.feature.group" version="1.8.0.201405281429"/>
+      <unit id="org.eclipse.emf.workspace.feature.group" version="1.8.0.201405281451"/>
+
+      <unit id="org.eclipse.uml2.feature.group" version="5.0.0.v20140602-0749"/>
+
+      <!-- Google Guava : Eclipse EMF -->
+      <unit id="com.google.guava" version="15.0.0.v201403281430"/>
+
+      <!-- Eclipse OCL/ALL -->
+      <unit id="org.eclipse.ocl.all.feature.group" version="5.0.0.v20140528-1458"/>
+
+      <unit id="javax.ws.rs" version="1.1.1.v20101004-1200"/>
+      <unit id="javax.xml.bind" version="2.1.9.v201005080401"/>
+
+      <unit id="org.eclipse.core.net" version="1.2.200.v20140124-2013"/>
+      <unit id="org.eclipse.equinox.cm" version="1.1.0.v20131021-1936"/>
+      <unit id="org.eclipse.equinox.security" version="1.2.0.v20130424-1801"/>      
+
+      <!-- BPMN2 Modeler -->
+      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.11.0.v20140528-0646"/>
+      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.11.0.v20140528-0646"/>
+      
+      <!-- Teiid -->
+      <unit id="org.apache.poi" version="3.9.0.v201303080712"/>
+      <unit id="org.eclipse.birt.report.data.oda.hive.ui" version="4.4.0.v201405191524"/>
+      <unit id="org.eclipse.birt.report.data.oda.hive" version="4.4.0.v201405191524"/>
+      <unit id="org.eclipse.birt.report.data.oda.jdbc.ui" version="4.4.0.v201405191524"/>
+      <unit id="org.eclipse.birt.report.data.oda.jdbc" version="4.4.0.v201405191524"/>
+      <unit id="org.eclipse.birt.report.data.bidi.utils.ui" version="4.4.0.v201405191524"/>
+      <unit id="org.eclipse.birt.report.data.bidi.utils" version="4.4.0.v201405191524"/>
+      <unit id="org.eclipse.birt.data.oda.mongodb.ui" version="4.4.0.v201405191524"/>
+      <unit id="org.eclipse.birt.data.oda.mongodb" version="4.4.0.v201405191524"/>
+      <unit id="org.eclipse.orbit.mongodb" version="2.10.1.v20130422-1135"/>
+      <unit id="org.eclipse.birt.core" version="4.4.0.v201405191524"/>
+
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/luna/201406120900-RC4/"/>
+    </location>
+
+    <!-- BPMN2 Modeler -->
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <unit id="org.eclipse.bpmn2.feature.group" version="1.0.0.201412192138"/>
+      <unit id="org.eclipse.bpmn2.modeler.feature.group" version="1.1.1.201501081320"/>
+      <unit id="org.eclipse.bpmn2.modeler.runtime.jboss.feature.group" version="1.1.1.201501081320"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/bpmn2-modeler/1.1.1.201501081320_1.0.0.201412192138_luna/"/>
+    </location>
+
+    <!-- BPEL -->
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <unit id="org.eclipse.bpel.common.feature.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.feature.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.common.feature.source.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.feature.source.feature.group" version="1.0.4.v201412041949"/>
+      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.source.feature.group" version="1.0.4.v201412041949"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/bpel/1.0.4.v201412041949/"/>
+    </location>
+
+    <!-- Fuse Tooling -->
+    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <unit id="org.eclipse.gemini.management" version="2.0.0.RELEASE"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/gemini/2.0.0.RELEASE/"/>
+    </location>
+
+    <!-- Teiid -->
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <unit id="org.codehaus.jackson.core" version="1.6.0.v20101005-0925"/>
+      <unit id="org.codehaus.jackson.mapper" version="1.6.0.v20101005-0925"/>
+      <unit id="javax.xml.soap" version="1.3.0.v201105210645"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/orbit/R20140525021250/"/>
+    </location>
+
+    <!-- JBoss Tools Core Tests -->
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
+
+      <!-- Required by BPEL, ESB, and any projects w/ UI tests -->
+      <!-- TODO: consider migrating UI tests to https://github.com/jbosstools/jbosstools-integration-tests/ so they're built downstream instead of within the components' builds -->
+      <unit id="org.jboss.tools.tests" version="3.5.0.Final-v20141016-2021-B66"/>
+      <unit id="org.jboss.tools.as.test.core" version="3.0.0.Final-v20141016-1911-B95"/>
+      <unit id="org.jboss.tools.common.base.test" version="3.6.0.Final-v20141016-2021-B66"/>
+      <unit id="org.jboss.tools.common.test" version="3.6.0.Final-v20141016-2021-B66"/>
+      <unit id="org.jboss.tools.jmx.core.test" version="1.6.0.Final-v20141016-1911-B95"/>
+      <repository location="http://download.jboss.org/jbosstools/static/releases/jbosstools-4.2.0.Final-updatesite-coretests/"/>
+    </location>
+
+  </locations>
+</target>

--- a/target-platform/integration-stack-base.target
+++ b/target-platform/integration-stack-base.target
@@ -3,6 +3,9 @@
 
 <!-- 
    Mirrored third-party and Eclipse dependencies for the JBoss Tools Integration Stack.
+
+   This target file should only contain released features/ plugins.  For non released 
+   artifacts see integration-stack-base-ea.target.
 -->
 <target name="integration-stack-base-target" sequenceNumber="7">
   <locations>
@@ -23,68 +26,8 @@
       <repository location="https://repository.jboss.org/nexus/content/unzip/unzip/org/jboss/tools/locus/update.site/1.1.1.Final/update.site-1.1.1.Final.zip-unzip/"/>
     </location>
 
-    <!-- transitive dependencies for org.springframework.* -->
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.springframework.aop" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.beans" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.context" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.core" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.expression" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.transaction" version="3.1.4.RELEASE"/>
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.2.0.201303060654-RELEASE-e4.3/"/>
-    </location>
-
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
 
-      <!-- transitive dependencies -->
-      <unit id="com.ibm.icu" version="52.1.0.v201404241930"/>
-      <unit id="javax.xml" version="1.3.4.v201005080400"/>
-      <unit id="org.apache.ant" version="1.9.2.v201404171502"/>
-      <unit id="org.apache.commons.codec" version="1.6.0.v201305230611"/>
-      <unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
-      <unit id="org.apache.commons.logging" version="1.0.4.v201101211617"/>
-      <unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
-
-      <unit id="org.eclipse.draw2d" version="3.9.100.201405261516"/>
-      <unit id="org.eclipse.equinox.simpleconfigurator.manipulator" version="2.0.0.v20131217-1203"/>
-      <unit id="org.eclipse.jdt.junit.core" version="3.7.300.v20140409-1618"/>
-      <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
-      <unit id="org.jsoup" version="1.7.2.v201304221138"/>
-      <unit id="org.junit" version="4.11.0.v201303080030"/>
-
-      <!-- Eclipse EMF -->
-      <unit id="org.eclipse.emf.compare.feature.group" version="3.0.0.201406111328"/>
-      <unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.0.0.201406111328"/>
-      <unit  id="org.eclipse.emf.compare.rcp" version="2.2.0.201406111328"/>
-      <unit  id="org.eclipse.emf.compare.rcp.ui" version="4.0.0.201406111328"/>
-
-      <!-- Eclipse EMF/OCL + deps like EMF Query and UML2 -->
-      <unit id="org.eclipse.emf.validation.ocl.feature.group" version="1.8.0.201405281429"/>
-      <unit id="org.eclipse.emf.query.ocl.feature.group" version="1.8.0.201405281426"/>
-      <unit id="org.eclipse.emf.query.feature.group" version="1.8.0.201405281426"/>
-      <unit id="org.eclipse.emf.transaction.feature.group" version="1.8.0.201405281451"/>
-      <unit id="org.eclipse.emf.validation.feature.group" version="1.8.0.201405281429"/>
-      <unit id="org.eclipse.emf.workspace.feature.group" version="1.8.0.201405281451"/>
-
-      <unit id="org.eclipse.uml2.feature.group" version="5.0.0.v20140602-0749"/>
-
-      <!-- Google Guava : Eclipse EMF -->
-      <unit id="com.google.guava" version="15.0.0.v201403281430"/>
-
-      <!-- Eclipse OCL/ALL -->
-      <unit id="org.eclipse.ocl.all.feature.group" version="5.0.0.v20140528-1458"/>
-
-      <unit id="javax.ws.rs" version="1.1.1.v20101004-1200"/>
-      <unit id="javax.xml.bind" version="2.1.9.v201005080401"/>
-
-      <unit id="org.eclipse.core.net" version="1.2.200.v20140124-2013"/>
-      <unit id="org.eclipse.equinox.cm" version="1.1.0.v20131021-1936"/>
-      <unit id="org.eclipse.equinox.security" version="1.2.0.v20130424-1801"/>      
-
-      <!-- BPMN2 Modeler -->
-      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.11.0.v20140528-0646"/>
-      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.11.0.v20140528-0646"/>
-      
       <!-- Teiid -->
       <unit id="org.apache.poi" version="3.9.0.v201303080712"/>
       <unit id="org.eclipse.birt.report.data.oda.hive.ui" version="4.4.0.v201405191524"/>
@@ -99,31 +42,6 @@
       <unit id="org.eclipse.birt.core" version="4.4.0.v201405191524"/>
 
       <repository location="http://download.jboss.org/jbosstools/updates/requirements/luna/201406120900-RC4/"/>
-    </location>
-
-    <!-- BPMN2 Modeler -->
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.bpmn2.feature.group" version="1.0.0.201412192138"/>
-      <unit id="org.eclipse.bpmn2.modeler.feature.group" version="1.1.1.201501081320"/>
-      <unit id="org.eclipse.bpmn2.modeler.runtime.jboss.feature.group" version="1.1.1.201501081320"/>
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/bpmn2-modeler/1.1.1.201501081320_1.0.0.201412192138_luna/"/>
-    </location>
-
-    <!-- BPEL -->
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.bpel.common.feature.feature.group" version="1.0.4.v201412041949"/>
-      <unit id="org.eclipse.bpel.feature.feature.group" version="1.0.4.v201412041949"/>
-      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.feature.group" version="1.0.4.v201412041949"/>
-      <unit id="org.eclipse.bpel.common.feature.source.feature.group" version="1.0.4.v201412041949"/>
-      <unit id="org.eclipse.bpel.feature.source.feature.group" version="1.0.4.v201412041949"/>
-      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.source.feature.group" version="1.0.4.v201412041949"/>
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/bpel/1.0.4.v201412041949/"/>
-    </location>
-
-    <!-- Fuse Tooling -->
-    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.gemini.management" version="2.0.0.RELEASE"/>
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/gemini/2.0.0.RELEASE/"/>
     </location>
 
     <!-- Teiid -->

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.jboss.tools.integration-stack</groupId>
   <artifactId>target-platform</artifactId>
-  <version>4.2.0.Final</version>
+  <version>4.2.1.CR1</version>
 
   <name>JBoss Tools Integration Stack Target Platform</name>
   <description>
@@ -118,16 +118,16 @@
 	<artifactId>target-platform-utils</artifactId>
 	<version>${jboss-tycho-version}</version>
 
+	<!-- Merge:
+	     1. released integration-stack specific target dependencies:   integration-stack-base.target
+	     2. the JBoss Tools core target dependencies:                + core-base.target
+	     3. the JBoss Tools unified core target dependencies:        + jbosstools-unified.target
+                                                                           =============================
+	     to generate an aggregate base target dependencies file:       aggregate-base.target
+        -->
 	<executions>
 
-	  <!-- Merge:
-
-	       1. the integration-stack specific target dependencies:   integration-stack-base.target
-	       2. the JBoss Tools core target dependencies:           + core-base.target
-	       3. the JBoss Tools unified core target dependencies:   + jbosstools-unified.target
-                                                                        _____________________________
-	       to generate an aggregate base target dependencies file:  aggregate-base.target
-            -->
+	  <!-- aggregate-base.target -->
 	  <execution>
 
 	    <id>merge-base</id>
@@ -157,10 +157,12 @@
 	    </configuration>
 	  </execution>
 
-	  <!-- Merge:
+	  <!-- aggregate-full.target
+
+	       Merge:
 	       1. the previously generated aggregate base target file:    aggregate-base.target
 	       2. the community-specific target dependencies:           + community.target
-                                                                          _____________________
+                                                                          ====================
 	       to generate the full community target dependencies file:   aggregate-full.target
 	    -->
 	  <execution>
@@ -183,10 +185,12 @@
 	    </configuration>
 	  </execution>
 
-	  <!-- Merge:
-	       1. the integration-stack specific target dependencies:   integration-stack-base.target
+	  <!-- integration-stack-community.target
+
+	       Merge:
+	       1. the integration-stack specific target dependencies:     integration-stack-base.target
 	       2. the community-specific target dependencies:           + community.target
-                                                                    _____________________
+                                                                          =================================
 	       to generate the full community target dependencies file:   integration-stack-community.target
 	    -->
 	  <execution>
@@ -205,6 +209,92 @@
 	      </sourceTargetFiles>
 
 	      <outputFile>${project.build.directory}/integration-stack-community.target</outputFile>
+
+	    </configuration>
+	  </execution>
+
+	  <!-- Merge:
+	       1. early access integration-stack specific target dependencies:       integration-stack-base-ea.target
+	       2. the JBoss Tools core target dependencies:                        + core-base.target
+	       3. the JBoss Tools unified core target dependencies:                + jbosstools-unified.target
+               =============================
+	       to generate an early access aggregate base target dependencies file:  aggregate-base-ea.target
+          -->
+	  <execution>
+
+	    <id>merge-base-ea</id>
+	    <phase>generate-resources</phase>
+	    <goals>
+	      <goal>merge-targets</goal>
+	    </goals>
+
+	    <configuration>
+
+	      <sourceTargetArtifacts>
+		<item>
+		  <groupId>org.jboss.tools.targetplatforms</groupId>
+		  <artifactId>jbosstools-unified</artifactId>
+		  <version>${JBTCoreTPVersion}</version>
+		  <classifier>jbosstools-unified</classifier>
+		</item>
+	      </sourceTargetArtifacts>
+
+	      <sourceTargetFiles>
+		<item>${basedir}/integration-stack-base-ea.target</item>
+		<item>${basedir}/core-base.target</item>
+	      </sourceTargetFiles>
+
+	      <outputFile>${project.build.directory}/aggregate-base-ea.target</outputFile>
+
+	    </configuration>
+	  </execution>
+
+	  <!-- Merge:
+	       1. the previously generated aggregate base target file:    aggregate-base-ea.target
+	       2. the community-specific target dependencies:           + community.target
+                                                                          ========================
+	       to generate the full community target dependencies file:   aggregate-full-ea.target
+	    -->
+	  <execution>
+	    <id>merge-community-full-ea</id>
+	    <phase>generate-resources</phase>
+	    <goals>
+	      <goal>merge-targets</goal>
+	    </goals>
+
+	    <configuration>
+
+	      <sourceTargetFiles>
+		<item>${basedir}/community.target</item>
+		<item>${project.build.directory}/aggregate-base-ea.target</item>
+	      </sourceTargetFiles>
+
+	      <outputFile>${project.build.directory}/aggregate-full-ea.target</outputFile>
+
+	    </configuration>
+	  </execution>
+
+	  <!-- Merge:
+	       1. the integration-stack specific target dependencies:     integration-stack-base-ea.target
+	       2. the community-specific target dependencies:           + community.target
+                                                                          ==================================
+	       to generate the full community target dependencies file:   integration-stack-community-ea.target
+	    -->
+	  <execution>
+	    <id>merge-community-ea</id>
+	    <phase>generate-resources</phase>
+	    <goals>
+	      <goal>merge-targets</goal>
+	    </goals>
+
+	    <configuration>
+
+	      <sourceTargetFiles>
+		<item>${basedir}/integration-stack-base-ea.target</item>
+		<item>${basedir}/community.target</item>
+	      </sourceTargetFiles>
+
+	      <outputFile>${project.build.directory}/integration-stack-community-ea.target</outputFile>
 
 	    </configuration>
 	  </execution>
@@ -231,6 +321,8 @@
 	      <targetFiles>
 		<param>${project.build.directory}/aggregate-base.target</param>
 		<param>${project.build.directory}/aggregate-full.target</param>
+		<param>${project.build.directory}/aggregate-base-ea.target</param>
+		<param>${project.build.directory}/aggregate-full-ea.target</param>
 	      </targetFiles>
 	      <failOnError>true</failOnError>
 
@@ -246,6 +338,7 @@
 	<version>1.3</version>
 
 	<executions>
+
 	  <execution>
 	    <id>attach-artifacts-base</id>
 	    <phase>package</phase>
@@ -311,15 +404,81 @@
 	    </configuration>
 	  </execution>
 
+	  <execution>
+	    <id>attach-artifacts-base-ea</id>
+	    <phase>package</phase>
+	    <goals>
+	      <goal>attach-artifact</goal>
+	    </goals>
+
+	    <configuration>
+
+	      <tasks>
+		<echo>Packaging the aggregated early access base target dependencies.</echo>
+	      </tasks>
+
+	      <artifacts>
+		<artifact>
+		  <file>${project.build.directory}/aggregate-base-ea.target</file>
+		  <type>target</type>
+		  <classifier>base-ea</classifier>
+		</artifact>
+	      </artifacts>
+
+	    </configuration>
+	  </execution>
+
+	  <execution>
+	    <id>attach-artifacts-full-ea</id>
+	    <phase>package</phase>
+	    <goals>
+	      <goal>attach-artifact</goal>
+	    </goals>
+
+	    <configuration>
+
+	      <tasks>
+		<echo>Packaging the aggregated early access full target dependencies (base + community).</echo>
+	      </tasks>
+
+	      <artifacts>
+		<artifact>
+		  <file>${project.build.directory}/aggregate-full-ea.target</file>
+		  <type>target</type>
+		  <classifier>full-ea</classifier>
+		</artifact>
+	      </artifacts>
+
+	    </configuration>
+	  </execution>
+
+	  <execution>
+	    <id>attach-artifacts-target-platform-base-ea</id>
+	    <phase>package</phase>
+	    <goals>
+	      <goal>attach-artifact</goal>
+	    </goals>
+	    <configuration>
+	      <artifacts>
+		<artifact>
+		  <file>integration-stack-base-ea.target</file>
+		  <type>target</type>
+		  <classifier>integration-stack-base-ea</classifier>
+		</artifact>
+	      </artifacts>
+	    </configuration>
+	  </execution>
+
 	</executions>
       </plugin>
 
     </plugins>
   </build>
 
-  <!-- Mirror just the integration stack target dependencies.  This will be used by the production
-       build as an extra repo.  -->
+  <!-- Mirror the integration stack target dependencies (release/ early/ early access).  This will be used by the 
+       production build as an extra repo.  -->
   <profiles>
+
     <profile>
       <id>mirror-integ-stack-target</id>
       <activation>
@@ -335,15 +494,33 @@
 	    <version>${jboss-tycho-version}</version>
 
 	    <executions>
+
+	      <!-- Mirror the integration stack target dependencies to a repository. -->
 	      <execution>
+		<id>mirror-target-platform-repo</id>
 		<phase>package</phase>
 		<goals>
 		  <goal>mirror-target-to-repo</goal>
 		</goals>
 		<configuration>
 		  <sourceTargetFile>${project.build.directory}/integration-stack-community.target</sourceTargetFile>
+		  <outputRepository>${project.build.directory}/${project.artifactId}.target.repo</outputRepository>
 		</configuration>
 	      </execution>
+
+	      <!-- Mirror the integration stack early access target dependencies to a repository. -->
+	      <execution>
+		<id>mirror-target-platform-repo-ea</id>
+		<phase>package</phase>
+		<goals>
+		  <goal>mirror-target-to-repo</goal>
+		</goals>
+		<configuration>
+		  <sourceTargetFile>${project.build.directory}/integration-stack-community-ea.target</sourceTargetFile>
+		  <outputRepository>${project.build.directory}/${project.artifactId}-ea.target.repo</outputRepository>
+		</configuration>
+	      </execution>
+
 	    </executions>
 	  </plugin>
 
@@ -353,7 +530,9 @@
 	    <version>1.7</version>
 
 	    <executions>
+
 	      <execution>
+		<id>package-target-platform-repo</id>
 		<phase>package</phase>
 
 		<configuration>
@@ -369,6 +548,25 @@
 		  <goal>run</goal>
 		</goals>
 	      </execution>
+
+	      <execution>
+		<id>package-target-platform-repo-ea</id>
+		<phase>package</phase>
+
+		<configuration>
+		  <quiet>true</quiet>
+		  <target>
+		    <!-- ANT script to remove the <references> section from the mirror repo content.xml. -->
+		    <ant antfile="../scripts/remove.references.xml" dir=".">
+		      <property name="workDir" value="./target/target-platform-ea.target.repo" />
+		    </ant>
+		  </target>
+		</configuration>
+		<goals>
+		  <goal>run</goal>
+		</goals>
+	      </execution>
+
 	    </executions>
 
 	    <dependencies>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -9,10 +9,18 @@
 
   <name>JBoss Tools Integration Stack Target Platform</name>
   <description>
-    JBoss Tools integration stack component target dependencies + JBoss Tools core target dependencies +
-    JBoss Tools unified core target dependencies forming an 'aggregate-base.target' combined target.
+    Create the JBTIS target platform files and optionally a mirrored repository.
 
-    Then add any leftover community dependencies to the aggregate forming an aggregate-full.target.
+    JBoss Tools integration stack component target dependencies + JBoss Tools core target dependencies +
+    JBoss Tools unified core target dependencies forming an 'aggregate-base.target' and an 
+    'aggregate-base-ea.target' combined target.
+
+    Then add any leftover community dependencies to the aggregate forming an 'aggregate-full.target'/
+    'aggregate-full-ea.target'.
+
+    Build -P mirror to get:
+       target-platform-ea.target.repo
+       target-platform.target.repo
   </description>
 
   <packaging>pom</packaging>
@@ -475,12 +483,13 @@
     </plugins>
   </build>
 
-  <!-- Mirror the integration stack target dependencies (release/ early/ early access).  This will be used by the 
-       production build as an extra repo.  -->
+  <!-- Mirror the integration stack target dependencies (release/ early access).  These will be used by the 
+       jbosstools and devstudio poms as an extra repo for resolving the contents of the .target files into a
+       repository. -->
   <profiles>
 
     <profile>
-      <id>mirror-integ-stack-target</id>
+      <id>mirror</id>
       <activation>
 	<activeByDefault>false</activeByDefault>
       </activation>


### PR DESCRIPTION
...m

Instead of having a target-platform artifact and an earlyaccess-target-platform artifact, it seemed more logical to place both the release and early access artifacts under 'target-platform'.  That makes them easier to deploy and to find.  Please see:

https://repository.jboss.org/nexus/#stagingRepositories - jboss_releases_staging_profile-4735

User's pom would then simply specify the EA classifier for early access.  e.g.:

\<artifact>
  \<groupId>org.jboss.tools.integration-stack</groupId>
   \<artifactId>target-platform</artifactId>
   \<version>${IS_TP_VERSION}</version>
   \<type>target</type>
   \<classifier>base-ea</classifier>
\</artifact>

And 'base' for the released TP artifact for the .Final/.GA build:

           <classifier>base</classifier> 
 
The default behavior is to build Final and EA for jbosstools (community).  The profiles are left to modify the update site descriptions in the index.html.  The devstudio profiles are left in place because they specify the targetplatform.url.

The 'site' site uses EA because that's what the discovery components are based on.

