### PR TITLE
JBTIS-430 - move fuse dependencies to release from ea

### DIFF
--- a/target-platform/integration-stack-base-ea.target
+++ b/target-platform/integration-stack-base-ea.target
@@ -9,17 +9,6 @@
 <target name="integration-stack-base-target" sequenceNumber="7">
   <locations>
 
-    <!-- transitive dependencies for org.springframework.* -->
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.springframework.aop" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.beans" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.context" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.core" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.expression" version="3.1.4.RELEASE"/>
-      <unit id="org.springframework.transaction" version="3.1.4.RELEASE"/>
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.2.0.201303060654-RELEASE-e4.3/"/>
-    </location>
-
     <!-- Fuse Tooling -->
     <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.gemini.management" version="2.0.0.RELEASE"/>

--- a/target-platform/integration-stack-base.target
+++ b/target-platform/integration-stack-base.target
@@ -124,5 +124,22 @@
       <repository location="http://download.jboss.org/jbosstools/static/releases/jbosstools-4.2.3.Final-updatesite-coretests/"/>
    </location>
 
+    <!-- transitive dependencies for org.springframework.* -->
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <unit id="org.springframework.aop" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.beans" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.context" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.core" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.expression" version="3.1.4.RELEASE"/>
+      <unit id="org.springframework.transaction" version="3.1.4.RELEASE"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/springide/3.2.0.201303060654-RELEASE-e4.3/"/>
+    </location>
+
+    <!-- Fuse Tooling -->
+    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+      <unit id="org.eclipse.gemini.management" version="2.0.0.RELEASE"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/gemini/2.0.0.RELEASE/"/>
+    </location>
+
   </locations>
 </target>


### PR DESCRIPTION
Move the Fuse Tooling dependencies from early access to the base classifier - Fuse Tooling is releasing in JBDSIS 8.0.2 - JBTIS TP 4.2.3.
