### PR TITLE
JBTIS-461 - update to jbds core beta2, eclipse mars rc4, add license …

### DIFF
--- a/jbosstools/pom.xml
+++ b/jbosstools/pom.xml
@@ -39,7 +39,7 @@
     <PREFIX>jbosstools-integration-stack</PREFIX>
     <TARGET_PLATFORM>mars</TARGET_PLATFORM>
     <VERSION>4.3.0.Alpha1</VERSION>
-    <IS_TP_VERSION>4.3.0.Beta1a</IS_TP_VERSION>
+    <IS_TP_VERSION>4.3.0.Beta1b-SNAPSHOT</IS_TP_VERSION>
     <tycho-version>0.21.0</tycho-version>
     <jboss-tycho-version>0.21.1</jboss-tycho-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/target-platform/core-base.target
+++ b/target-platform/core-base.target
@@ -10,61 +10,63 @@
     <!-- JBoss Tools Core Base Dependencies
          ref: <repository loc>/site.properties -->
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.hibernate.eclipse.feature.feature.group" version="5.0.0.Beta1-v20150613-2054-B23"/>
-      <unit id="org.jboss.ide.eclipse.archives.feature.feature.group" version="3.6.0.Beta1-v20150612-2158-B25"/>
-      <unit id="org.jboss.ide.eclipse.as.feature.feature.group" version="3.1.0.Beta1-v20150612-2158-B25"/>
-      <unit id="org.jboss.ide.eclipse.freemarker.feature.feature.group" version="1.4.101.Beta1-v20150611-1539-B7"/>
-      <unit id="org.jboss.tools.cdi.deltaspike.feature.feature.group" version="1.7.0.Beta1-v20150605-0417-B17"/>
-      <unit id="org.jboss.tools.cdi.feature.feature.group" version="1.7.0.Beta1-v20150605-0417-B17"/>
-      <unit id="org.jboss.tools.cdi.seam.feature.feature.group" version="1.7.0.Beta1-v20150605-0417-B17"/>
-      <unit id="org.jboss.tools.central.feature.feature.group" version="2.0.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.discovery.core" version="1.0.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.common.core.feature.feature.group" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.common.feature.feature.group" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.common.jdt.feature.feature.group" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.common.mylyn.feature.feature.group" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.common.text.ext.feature.feature.group" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.common.ui.feature.feature.group" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.common.verification.feature.feature.group" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.common.feature.feature.group" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.forge.feature.feature.group" version="2.0.0.Beta1-v20150612-2200-B24"/>
-      <unit id="org.jboss.tools.forge.ext.feature.feature.group" version="2.0.0.Beta1-v20150612-2200-B24"/>
-      <unit id="org.jboss.tools.foundation.feature.feature.group" version="1.2.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.foundation.security.linux.feature.feature.group" version="1.2.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.foundation.help.ui" version="1.2.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.jmx.feature.feature.group" version="1.7.0.Beta1-v20150612-2158-B25"/>
-      <unit id="org.jboss.tools.jsf.feature.feature.group" version="3.7.0.Beta1-v20150605-0417-B17"/>
-      <unit id="org.jboss.tools.jst.feature.feature.group" version="3.7.0.Beta1-v20150608-1702-B23"/>
-      <unit id="org.jboss.tools.livereload.feature.feature.group" version="1.3.0.Beta1-v20150615-1934-B20"/>
+      <unit id="org.hibernate.eclipse.feature.feature.group" version="5.0.0.Beta2-v20150711-1506-B1023"/>
+      <unit id="org.jboss.ide.eclipse.archives.feature.feature.group" version="3.6.0.Beta2-v20150709-1626-B809"/>
+      <unit id="org.jboss.ide.eclipse.as.feature.feature.group" version="3.1.0.Beta2-v20150709-1626-B809"/>
+      <unit id="org.jboss.ide.eclipse.freemarker.feature.feature.group" version="1.4.101.Beta2-v20150711-0625-B284"/>
+      <unit id="org.jboss.tools.cdi.deltaspike.feature.feature.group" version="1.7.0.Beta2-v20150711-0417-B825"/>
+      <unit id="org.jboss.tools.cdi.feature.feature.group" version="1.7.0.Beta2-v20150711-0417-B825"/>
+      <unit id="org.jboss.tools.cdi.seam.feature.feature.group" version="1.7.0.Beta2-v20150711-0417-B825"/>
+      <unit id="org.jboss.tools.central.feature.feature.group" version="2.0.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.discovery.core" version="1.0.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.common.core.feature.feature.group" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.common.feature.feature.group" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.common.jdt.feature.feature.group" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.common.mylyn.feature.feature.group" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.common.text.ext.feature.feature.group" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.common.ui.feature.feature.group" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.common.verification.feature.feature.group" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.common.feature.feature.group" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.forge.feature.feature.group" version="2.0.0.Beta2-v20150621-2246-B894"/>
+      <unit id="org.jboss.tools.forge.ext.feature.feature.group" version="2.0.0.Beta2-v20150621-2246-B894"/>
+      <unit id="org.jboss.tools.foundation.feature.feature.group" version="1.2.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.foundation.security.linux.feature.feature.group" version="1.2.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.foundation.help.ui" version="1.2.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.foundation.license.feature.feature.group" version="1.2.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.jmx.feature.feature.group" version="1.7.0.Beta2-v20150709-1626-B809"/>
+      <unit id="org.jboss.tools.jsf.feature.feature.group" version="3.7.0.Beta2-v20150711-0417-B825"/>
+      <unit id="org.jboss.tools.jst.feature.feature.group" version="3.7.0.Beta2-v20150711-0257-B901"/>
+      <unit id="org.jboss.tools.livereload.feature.feature.group" version="1.3.0.Beta2-v20150710-2036-B363"/>
       <unit id="org.jboss.tools.maven.apt.feature.feature.group" version="1.1.1.201411262015"/>
-      <unit id="org.jboss.tools.maven.cdi.feature.feature.group" version="1.7.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.maven.feature.feature.group" version="1.7.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.maven.hibernate.feature.feature.group" version="1.7.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.maven.jbosspackaging.feature.feature.group" version="1.7.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.maven.jdt.feature.feature.group" version="1.7.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.maven.portlet.feature.feature.group" version="1.7.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.maven.project.examples.feature.feature.group" version="3.0.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.maven.seam.feature.feature.group" version="1.7.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.maven.sourcelookup.feature.feature.group" version="1.7.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.openshift.egit.integration.feature.feature.group" version="3.0.0.Beta2-v20150613-0235-B25"/>
-      <unit id="org.jboss.tools.openshift.express.feature.feature.group" version="3.0.0.Beta2-v20150613-0235-B25"/>
+      <unit id="org.jboss.tools.maven.cdi.feature.feature.group" version="1.7.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.maven.feature.feature.group" version="1.7.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.maven.hibernate.feature.feature.group" version="1.7.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.maven.jbosspackaging.feature.feature.group" version="1.7.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.maven.jdt.feature.feature.group" version="1.7.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.maven.portlet.feature.feature.group" version="1.7.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.maven.project.examples.feature.feature.group" version="3.0.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.maven.seam.feature.feature.group" version="1.7.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.maven.sourcelookup.feature.feature.group" version="1.7.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.openshift.egit.integration.feature.feature.group" version="3.0.0.Beta2-v20150710-1837-B871"/>
+      <unit id="org.jboss.tools.openshift.express.feature.feature.group" version="3.0.0.Beta2-v20150710-1837-B871"/>
       <unit id="org.jboss.tools.portlet.feature.feature.group" version="1.6.0.Final-v20141209-0339-B20"/>
-      <unit id="org.jboss.tools.project.examples.feature.feature.group" version="3.0.0.Beta1-v20150619-0016-B31"/>
-      <unit id="org.jboss.tools.richfaces.feature.feature.group" version="3.7.0.Beta1-v20150605-0417-B17"/>
-      <unit id="org.jboss.tools.runtime.core.feature.feature.group" version="3.1.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.runtime.seam.detector.feature.feature.group" version="3.7.0.Beta1-v20150605-0417-B17"/>
-      <unit id="org.jboss.tools.seam.feature.feature.group" version="3.7.0.Beta1-v20150605-0417-B17"/>
-      <unit id="org.jboss.tools.stacks.core.feature.feature.group" version="1.2.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.usage" version="2.1.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.browsersim.feature.feature.group" version="3.7.0.Beta1-v20150604-2147-B21"/>
-      <unit id="org.jboss.tools.vpe.feature.feature.group" version="3.7.0.Beta1-v20150604-2142-B20"/>
-      <unit id="org.jboss.tools.ws.feature.feature.group" version="1.8.0.Beta1-v20150605-0156-B18"/>
-      <unit id="org.jboss.tools.ws.jaxrs.feature.feature.group" version="1.8.0.Beta1-v20150605-0156-B18"/>
-      <unit id="org.jboss.tools.wtp.runtimes.tomcat.feature.feature.group" version="1.3.0.Beta1-v20150612-2158-B25"/>
+      <unit id="org.jboss.tools.project.examples.feature.feature.group" version="3.0.0.Beta2-v20150626-1903-B740"/>
+      <unit id="org.jboss.tools.richfaces.feature.feature.group" version="3.7.0.Beta2-v20150711-0417-B825"/>
+      <unit id="org.jboss.tools.runtime.core.feature.feature.group" version="3.1.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.runtime.seam.detector.feature.feature.group" version="3.7.0.Beta2-v20150711-0417-B825"/>
+      <unit id="org.jboss.tools.seam.feature.feature.group" version="3.7.0.Beta2-v20150711-0417-B825"/>
+      <unit id="org.jboss.tools.stacks.core.feature.feature.group" version="1.2.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.usage" version="2.1.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.browsersim.feature.feature.group" version="3.7.0.Beta2-v20150707-2110-B208"/>
+      <unit id="org.jboss.tools.vpe.feature.feature.group" version="3.7.0.Beta2-v20150702-1554-B739"/>
+      <unit id="org.jboss.tools.ws.feature.feature.group" version="1.8.0.Beta2-v20150710-1752-B774"/>
+      <unit id="org.jboss.tools.ws.jaxrs.feature.feature.group" version="1.8.0.Beta2-v20150710-1752-B774"/>
+      <unit id="org.jboss.tools.wtp.runtimes.tomcat.feature.feature.group" version="1.3.0.Beta2-v20150709-1626-B809"/>
       <unit id="org.mozilla.xpcom" version="1.9.2.16"/>
 
       <!-- "http://download.jboss.org/jbosstools/mars/staging/updates/core/4.3.0.Beta1c/" -->
-      <repository location="http://download.jboss.org/jbosstools/static/mars/development/updates/core/4.3.0.Beta1/"/>
+      <repository location="http://download.jboss.org/jbosstools/mars/snapshots/updates/core/master/"/>
+<!--      <repository location="http://download.jboss.org/jbosstools/static/mars/development/updates/core/4.3.0.Beta1/"/> -->
    </location>
 
   </locations>

--- a/target-platform/integration-stack-base-ea.target
+++ b/target-platform/integration-stack-base-ea.target
@@ -11,13 +11,13 @@
 
     <!-- BPEL -->
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.bpel.common.feature.feature.group" version="1.0.4.Final"/>
-      <unit id="org.eclipse.bpel.feature.feature.group" version="1.0.4.Final"/>
-      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.feature.group" version="1.0.4.Final"/>
-      <unit id="org.eclipse.bpel.common.feature.source.feature.group" version="1.0.4.Final"/>
-      <unit id="org.eclipse.bpel.feature.source.feature.group" version="1.0.4.Final"/>
-      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.source.feature.group" version="1.0.4.Final"/>
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/bpel/1.0.4.Final/"/>
+      <unit id="org.eclipse.bpel.common.feature.feature.group" version="1.0.5.Final"/>
+      <unit id="org.eclipse.bpel.feature.feature.group" version="1.0.5.Final"/>
+      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.feature.group" version="1.0.5.Final"/>
+      <unit id="org.eclipse.bpel.common.feature.source.feature.group" version="1.0.5.Final"/>
+      <unit id="org.eclipse.bpel.feature.source.feature.group" version="1.0.5.Final"/>
+      <unit id="org.eclipse.bpel.apache.ode.runtime.feature.source.feature.group" version="1.0.5.Final"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/bpel/1.0.5.Final/"/>
     </location>
 
     <!-- JBoss Tools Locus - objects either not in Eclipse Orbit or needed sooner than scheduled. -->
@@ -39,22 +39,22 @@
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
 
       <!-- Eclipse EMF -->
-      <unit id="org.eclipse.emf.compare.feature.group" version="3.1.0.201505261421"/>
-      <unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.1.0.201505261421"/>
-      <unit id="org.eclipse.emf.compare.rcp" version="2.3.0.201505261421"/>
-      <unit id="org.eclipse.emf.compare.rcp.ui" version="4.1.0.201505261421"/>
+      <unit id="org.eclipse.emf.compare.feature.group" version="3.1.0.201506080833"/>
+      <unit id="org.eclipse.emf.compare.ide.ui.feature.group" version="3.1.0.201506080833"/>
+      <unit id="org.eclipse.emf.compare.rcp" version="2.3.0.201506080833"/>
+      <unit id="org.eclipse.emf.compare.rcp.ui" version="4.1.0.201506080833"/>
 
       <!-- Eclipse EMF/OCL + deps like EMF Query and UML2 -->
-      <unit id="org.eclipse.emf.validation.ocl.feature.group" version="1.9.0.201505060134"/>
-      <unit id="org.eclipse.emf.query.ocl.feature.group" version="1.9.0.201505060133"/>
-      <unit id="org.eclipse.emf.query.feature.group" version="1.9.0.201505060133"/>
-      <unit id="org.eclipse.emf.transaction.feature.group" version="1.9.0.201505060251"/>
-      <unit id="org.eclipse.emf.validation.feature.group" version="1.9.0.201505060134"/>
-      <unit id="org.eclipse.emf.workspace.feature.group" version="1.9.0.201505060251"/>
+      <unit id="org.eclipse.emf.validation.ocl.feature.group" version="1.9.0.201505312255"/>
+      <unit id="org.eclipse.emf.query.ocl.feature.group" version="1.9.0.201505312221"/>
+      <unit id="org.eclipse.emf.query.feature.group" version="1.9.0.201505312221"/>
+      <unit id="org.eclipse.emf.transaction.feature.group" version="1.9.0.201506010221"/>
+      <unit id="org.eclipse.emf.validation.feature.group" version="1.9.0.201505312255"/>
+      <unit id="org.eclipse.emf.workspace.feature.group" version="1.9.0.201506010221"/>
       <unit id="org.eclipse.emf.ecore.feature.group" version="2.11.0.v20150512-0501"/>
-      <unit id="org.eclipse.emf.codegen.ecore.ui.feature.group" version="2.11.0.v20150518-0831"/>
+      <unit id="org.eclipse.emf.codegen.ecore.ui.feature.group" version="2.11.0.v20150601-0402"/>
 
-      <unit id="org.eclipse.uml2.feature.group" version="5.1.0.v20150525-0937"/>
+      <unit id="org.eclipse.uml2.feature.group" version="5.1.0.v20150601-0733"/>
 
       <!-- Google Guava : Eclipse EMF -->
       <unit id="com.google.guava" version="15.0.0.v201403281430"/>
@@ -73,32 +73,32 @@
       <unit id="org.apache.commons.logging" version="1.0.4.v201101211617"/>
       <unit id="org.apache.commons.logging" version="1.1.1.v201101211721"/>
 
-      <unit id="org.eclipse.draw2d" version="3.10.0.201505250205"/>
+      <unit id="org.eclipse.draw2d" version="3.10.0.201506010206"/>
       <unit id="org.hamcrest.core" version="1.3.0.v201303031735"/>
-      <unit id="org.jsoup" version="1.7.2.v201304221138"/>
+      <unit id="org.jsoup" version="1.7.2.v201411291515"/>
       <unit id="org.junit" version="4.11.0.v201303080030"/>
 
       <!-- Teiid -->
       <unit id="org.apache.poi" version="3.9.0.v201405241750"/>
-      <unit id="org.eclipse.birt.report.data.oda.hive.ui" version="4.5.0.v201505260702"/>
-      <unit id="org.eclipse.birt.report.data.oda.hive" version="4.5.0.v201505260702"/>
-      <unit id="org.eclipse.birt.report.data.oda.jdbc.ui" version="4.5.0.v201505260702"/>
-      <unit id="org.eclipse.birt.report.data.oda.jdbc" version="4.5.0.v201505260702"/>
-      <unit id="org.eclipse.birt.report.data.bidi.utils.ui" version="4.5.0.v201505260702"/>
-      <unit id="org.eclipse.birt.report.data.bidi.utils" version="4.5.0.v201505260702"/>
-      <unit id="org.eclipse.birt.data.oda.mongodb.ui" version="4.5.0.v201505260702"/>
-      <unit id="org.eclipse.birt.data.oda.mongodb" version="4.5.0.v201505260702"/>
+      <unit id="org.eclipse.birt.report.data.oda.hive.ui" version="4.5.0.v201506092134"/>
+      <unit id="org.eclipse.birt.report.data.oda.hive" version="4.5.0.v201506092134"/>
+      <unit id="org.eclipse.birt.report.data.oda.jdbc.ui" version="4.5.0.v201506092134"/>
+      <unit id="org.eclipse.birt.report.data.oda.jdbc" version="4.5.0.v201506092134"/>
+      <unit id="org.eclipse.birt.report.data.bidi.utils.ui" version="4.5.0.v201506092134"/>
+      <unit id="org.eclipse.birt.report.data.bidi.utils" version="4.5.0.v201506092134"/>
+      <unit id="org.eclipse.birt.data.oda.mongodb.ui" version="4.5.0.v201506092134"/>
+      <unit id="org.eclipse.birt.data.oda.mongodb" version="4.5.0.v201506092134"/>
       <unit id="org.eclipse.orbit.mongodb" version="2.10.1.v20130422-1135"/>
-      <unit id="org.eclipse.birt.core" version="4.5.0.v201505260702"/>
+      <unit id="org.eclipse.birt.core" version="4.5.0.v201506092134"/>
 
       <!-- BPMN2 Modeler -->
-      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.12.0.v20150527-0901"/>
-      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.12.0.v20150527-0901"/>
+      <unit id="org.eclipse.graphiti.feature.feature.group" version="0.12.0.v20150603-0807"/>
+      <unit id="org.eclipse.graphiti.export.feature.feature.group" version="0.12.0.v20150603-0807"/>
       
       <unit id="org.eclipse.core.net" version="1.2.300.v20141118-1725"/>
       <unit id="org.eclipse.equinox.cm" version="1.1.100.v20150205-1358"/>
 
-      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mars/201505291000-RC2/"/>
+      <repository location="http://download.jboss.org/jbosstools/updates/requirements/mars/201506121000-RC4/"/>
     </location>
 
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">

--- a/target-platform/integration-stack-base.target
+++ b/target-platform/integration-stack-base.target
@@ -15,20 +15,22 @@
 
       <!-- Required by BPEL, ESB, and any projects w/ UI tests -->
       <!-- TODO: consider migrating UI tests to https://github.com/jbosstools/jbosstools-integration-tests/ so they're built downstream instead of within the components' builds -->
-      <unit id="org.jboss.tools.tests" version="3.6.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.as.test.core" version="3.1.0.Beta1-v20150612-2158-B25"/>
-      <unit id="org.jboss.tools.common.base.test" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.common.test" version="3.7.0.Beta1-v20150608-1702-B21"/>
-      <unit id="org.jboss.tools.jmx.core.test" version="1.7.0.Beta1-v20150612-2158-B25"/>
+      <unit id="org.jboss.tools.tests" version="3.6.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.as.test.core" version="3.1.0.Beta2-v20150709-1626-B809"/>
+      <unit id="org.jboss.tools.common.base.test" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.common.test" version="3.7.0.Beta2-v20150711-0435-B766"/>
+      <unit id="org.jboss.tools.jmx.core.test" version="1.7.0.Beta2-v20150709-1626-B809"/>
 
-      <repository location="http://download.jboss.org/jbosstools/mars/staging/updates/coretests/4.3.0.Beta1a/"/>
+      <!-- <repository location="http://download.jboss.org/jbosstools/static/mars/development/updates/coretests/4.3.0.Beta1/"/> -->
+      <repository location="http://download.jboss.org/jbosstools/mars/snapshots/updates/coretests/master/"/>
    </location>
 
    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
-      <unit id="org.jboss.tools.common" version="3.7.0.Beta1-v20150608-1702-B21"/>
+      <unit id="org.jboss.tools.common" version="3.7.0.Beta2-v20150711-0435-B766"/>
 
       <!-- "http://download.jboss.org/jbosstools/mars/staging/updates/core/4.3.0.Beta1c/" -->
-      <repository location="http://download.jboss.org/jbosstools/static/mars/development/updates/core/4.3.0.Beta1/"/>
+      <!-- <repository location="http://download.jboss.org/jbosstools/static/mars/development/updates/core/4.3.0.Beta1/"/> -->
+      <repository location="http://download.jboss.org/jbosstools/mars/snapshots/updates/core/master/"/>
    </location>
 
   </locations>

--- a/target-platform/pom.xml
+++ b/target-platform/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.jboss.tools.integration-stack</groupId>
   <artifactId>target-platform</artifactId>
-  <version>4.3.0.Beta1a</version>
+  <version>4.3.0.Beta1b-SNAPSHOT</version>
 
   <name>JBoss Tools Integration Stack Target Platform</name>
   <description>
@@ -37,7 +37,7 @@
     <tychoVersion>0.22.0</tychoVersion>
     <tychoExtrasVersion>${tychoVersion}</tychoExtrasVersion>
     <jboss-tycho-version>0.22.1-SNAPSHOT</jboss-tycho-version>
-    <JBTCoreTPVersion>4.50.0.Beta1</JBTCoreTPVersion>
+    <JBTCoreTPVersion>4.50.0.Beta2-SNAPSHOT</JBTCoreTPVersion>
   </properties>
 
   <reporting>


### PR DESCRIPTION
…feature

Pick up license feature and update: 
JBT core TP: 4.50.0.Beta2-SNAPSHOT
JBoss Tools core target dependencies: 4.3.0.Beta2
BPEL: 1.0.5.Final
Eclipse Mars: mars/201506121000-RC4/