### PR TITLE
JBIDE-24240 JBIDE-24376 add...

### DIFF
--- a/devstudio/discovery/com.jboss.jbds.central.discovery.integration-stack/plugin.xml
+++ b/devstudio/discovery/com.jboss.jbds.central.discovery.integration-stack/plugin.xml
@@ -60,6 +60,7 @@
        <iu id="org.switchyard.tools.feature"/>
        <iu id="org.switchyard.tools.bpel.feature"/>
        <iu id="org.switchyard.tools.bpmn2.feature"/>
+       <iu id="org.eclipse.wst.common_core_EBZ511793.feature.patch"/>
        <icon
           image32="images/jbds_icon32.png">
        </icon>
@@ -147,7 +148,7 @@
        <iu id="org.switchyard.tools.feature"/>
        <iu id="org.switchyard.tools.bpel.feature"/>
        <iu id="org.switchyard.tools.bpmn2.feature"/>
-
+       <iu id="org.eclipse.wst.common_core_EBZ511793.feature.patch"/>
       <icon
         image32="images/jbds_icon32.png">
       </icon>

--- a/jbosstools/discovery/org.jboss.tools.central.discovery.integration-stack/plugin.xml
+++ b/jbosstools/discovery/org.jboss.tools.central.discovery.integration-stack/plugin.xml
@@ -106,6 +106,7 @@
        <iu id="org.switchyard.tools.feature"/>
        <iu id="org.switchyard.tools.bpel.feature"/>
        <iu id="org.switchyard.tools.bpmn2.feature"/>
+       <iu id="org.eclipse.wst.common_core_EBZ511793.feature.patch"/>
        <icon
           image32="images/jbds_fuse_32.png">
        </icon>


### PR DESCRIPTION
JBIDE-24240 JBIDE-24376 add org.eclipse.wst.common_core_EBZ511793.feature.patch from JBT/devstudio as requirement for fuse connectors, so we guarantee the patch is applied when installing Fuse

Signed-off-by: nickboldt <nboldt@redhat.com>